### PR TITLE
Fix forward auth hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# n8n-community-sso
+# n8n Community SSO via External Hook
+
+This repository provides an example `hooks.js` file that enables basic single sign-on for the community edition of **n8n** using an authenticating reverse proxy (e.g. Keycloak, Authelia). The hook listens for the `n8n.ready` event and attaches middleware to n8n's internal Express app to automatically log in users based on a forwarded email header.
+
+## Usage
+
+1. Mount `hooks.js` into your n8n container and set the environment variables:
+
+```bash
+EXTERNAL_HOOK_FILES=/home/node/.n8n/hooks.js
+N8N_FORWARD_AUTH_HEADER=Remote-Email
+```
+
+2. Configure your proxy to authenticate users and pass their email in the header defined by `N8N_FORWARD_AUTH_HEADER`.
+3. Ensure the user already exists in n8n (invite them via the UI or API). If the user is found, the middleware issues the normal n8n auth cookie so the user is considered logged in.
+
+Requests that already contain a valid `n8n-auth` cookie or match public routes like `/assets`, `/healthz`, `/webhook`, or `/rest/oauth2-credential` are ignored.
+
+The hook exports the `n8n.ready` handler in the modern format (`module.exports = { n8n: { ready: [...] } }`) and inserts the middleware right after the cookie parser layer for seamless integration.
+
+See `hooks.js` for the implementation details.

--- a/hooks.js
+++ b/hooks.js
@@ -1,0 +1,46 @@
+module.exports = {
+  n8n: {
+    ready: [
+      async function ({ app }, config) {
+        const headerName = process.env.N8N_FORWARD_AUTH_HEADER;
+        if (!headerName) {
+          this.logger?.info('N8N_FORWARD_AUTH_HEADER not set; SSO middleware disabled.');
+          return;
+        }
+
+        const Layer = require('router/lib/layer');
+        const { dirname, resolve } = require('path');
+        const { issueCookie } = require(resolve(dirname(require.resolve('n8n')), 'auth/jwt'));
+        const ignoreAuth = /^\/(assets|healthz|webhook|rest\/oauth2-credential)/;
+        const cookieName = 'n8n-auth';
+        const UserRepo = this.dbCollections.User;
+
+        const { stack } = app.router;
+        const idx = stack.findIndex((l) => l?.name === 'cookieParser');
+        const layer = new Layer('/', { strict: false, end: false }, async (req, res, next) => {
+          try {
+            if (ignoreAuth.test(req.url)) return next();
+            if (!config.get('userManagement.isInstanceOwnerSetUp', false)) return next();
+            if (req.cookies?.[cookieName]) return next();
+            const email = req.headers[headerName.toLowerCase()];
+            if (!email) return next();
+            const userEmail = Array.isArray(email) ? email[0] : String(email);
+            const user = await UserRepo.findOneBy({ email: userEmail });
+            if (!user) {
+              res.statusCode = 401;
+              res.end(`User ${userEmail} not found, please invite the user first.`);
+              return;
+            }
+            issueCookie(res, user);
+            req.user = user;
+            req.userId = user.id;
+            return next();
+          } catch (error) {
+            return next(error);
+          }
+        });
+        stack.splice(idx + 1, 0, layer);
+      }
+    ]
+  }
+};


### PR DESCRIPTION
## Summary
- export hooks using the modern namespace structure
- insert middleware right after cookie parser on `n8n.ready`
- document updated hook format in README

## Testing
- `node -c hooks.js`


------
https://chatgpt.com/codex/tasks/task_e_6878c1f14fa08329ba3ecfe3a8f1ba95